### PR TITLE
Make serde_json dependency optional and enabled by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,9 @@ env:
   - ARCH=i686
 notifications:
   email: false
+matrix:
+  - env: CARGO_OPTIONS='--verbose'
+  - env: CARGO_OPTIONS='--verbose --no-default-features'
+script:
+  - cargo build $CARGO_OPTIONS
+  - cargo test $CARGO_OPTIONS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,12 @@ repository = "https://github.com/nagisa/target_build_utils.rs"
 documentation = "https://docs.rs/target_build_utils"
 build = "build.rs"
 
+[features]
+default = ["serde_json"]
+
 [dependencies]
-serde_json="0.9"
-phf="0.7"
+serde_json = { version = "0.9", optional = true }
+phf = "0.7"
 
 [build-dependencies]
-phf_codegen="0.7"
+phf_codegen = "0.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,3 +17,4 @@ install:
 build: off
 test_script:
   - cargo test
+  - cargo test --no-default-features


### PR DESCRIPTION
This PR is to fix https://github.com/servo/rust-bindgen/issues/499.
It adds a ```serde_json``` feature enabled by default.

Tests pass both with and without the feature enabled and the CI configs have been updated (I don't know much about those two CI systems though, so the changes to the config might not be correct).